### PR TITLE
Add structured shopping list JSON derived from weekly menus

### DIFF
--- a/courses.json
+++ b/courses.json
@@ -1,0 +1,443 @@
+{
+  "metadata": {
+    "menus_source": "menus.json",
+    "nombre_personnes": 2,
+    "frequence_generation": "hebdomadaire"
+  },
+  "items": [
+    {
+      "slug": "lentilles",
+      "display_name": "Lentilles corail sèches",
+      "category": "Épicerie sèche",
+      "quantity": {"amount": 200, "unit": "g"},
+      "purchase_form": "sec",
+      "store": {
+        "coop": {
+          "search_terms": ["lentilles corail", "lentilles rouges"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas1"]
+    },
+    {
+      "slug": "lait_coco",
+      "display_name": "Lait de coco en boîte",
+      "category": "Épicerie asiatique",
+      "quantity": {"amount": 400, "unit": "ml"},
+      "purchase_form": "conserve",
+      "store": {
+        "coop": {
+          "search_terms": ["lait de coco bio"],
+          "preferred_section": "Épicerie du monde"
+        }
+      },
+      "recipes": ["Repas1"]
+    },
+    {
+      "slug": "epinards",
+      "display_name": "Épinards frais ou surgelés",
+      "category": "Légumes",
+      "quantity": {"amount": 200, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["épinards frais", "épinards en branches"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas1"]
+    },
+    {
+      "slug": "patate_douce",
+      "display_name": "Patates douces",
+      "category": "Légumes",
+      "quantity": {"amount": 500, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["patate douce"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas1"]
+    },
+    {
+      "slug": "gingembre",
+      "display_name": "Racine de gingembre",
+      "category": "Épicerie fraîche",
+      "quantity": {"amount": 20, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["gingembre frais"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas1"]
+    },
+    {
+      "slug": "pois_chiches",
+      "display_name": "Pois chiches cuits (bocal ou boîte)",
+      "category": "Épicerie sèche",
+      "quantity": {"amount": 400, "unit": "g"},
+      "purchase_form": "conserve",
+      "store": {
+        "coop": {
+          "search_terms": ["pois chiches bio"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas2"]
+    },
+    {
+      "slug": "tomates",
+      "display_name": "Tomates fraîches",
+      "category": "Légumes",
+      "quantity": {"amount": 1000, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["tomates grappe", "tomates salade"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas2", "Repas5"]
+    },
+    {
+      "slug": "concombre",
+      "display_name": "Concombre",
+      "category": "Légumes",
+      "quantity": {"amount": 1, "unit": "pièce"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["concombre"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas2"]
+    },
+    {
+      "slug": "persil",
+      "display_name": "Persil frais",
+      "category": "Herbes fraîches",
+      "quantity": {"amount": 1, "unit": "botte"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["persil plat", "persil frisé"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas2"]
+    },
+    {
+      "slug": "citron",
+      "display_name": "Citrons jaunes",
+      "category": "Fruits",
+      "quantity": {"amount": 3, "unit": "pièces"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["citron bio"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas2", "Repas3"]
+    },
+    {
+      "slug": "saumon",
+      "display_name": "Filets de saumon",
+      "category": "Poissonnerie",
+      "quantity": {"amount": 300, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["saumon frais", "saumon label ASC"],
+          "preferred_section": "Poissonnerie"
+        }
+      },
+      "recipes": ["Repas3"]
+    },
+    {
+      "slug": "quinoa",
+      "display_name": "Quinoa",
+      "category": "Épicerie sèche",
+      "quantity": {"amount": 200, "unit": "g"},
+      "purchase_form": "sec",
+      "store": {
+        "coop": {
+          "search_terms": ["quinoa bio"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas3"]
+    },
+    {
+      "slug": "courgettes",
+      "display_name": "Courgettes",
+      "category": "Légumes",
+      "quantity": {"amount": 2, "unit": "pièces"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["courgette verte"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas3"]
+    },
+    {
+      "slug": "aneth",
+      "display_name": "Aneth frais",
+      "category": "Herbes fraîches",
+      "quantity": {"amount": 1, "unit": "botte"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["aneth frais"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas3"]
+    },
+    {
+      "slug": "tofu",
+      "display_name": "Tofu fumé",
+      "category": "Produits végétariens",
+      "quantity": {"amount": 200, "unit": "g"},
+      "purchase_form": "réfrigéré",
+      "store": {
+        "coop": {
+          "search_terms": ["tofu fumé"],
+          "preferred_section": "Produits frais"
+        }
+      },
+      "recipes": ["Repas4"]
+    },
+    {
+      "slug": "brocoli",
+      "display_name": "Brocoli",
+      "category": "Légumes",
+      "quantity": {"amount": 1, "unit": "pièce"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["brocoli"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas4"]
+    },
+    {
+      "slug": "champignons",
+      "display_name": "Champignons de Paris",
+      "category": "Légumes",
+      "quantity": {"amount": 500, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["champignons de Paris"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas4", "Repas7"]
+    },
+    {
+      "slug": "ail",
+      "display_name": "Tête d'ail",
+      "category": "Épicerie fraîche",
+      "quantity": {"amount": 1, "unit": "tête"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["ail frais"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas4"]
+    },
+    {
+      "slug": "tamari",
+      "display_name": "Sauce tamari",
+      "category": "Épicerie asiatique",
+      "quantity": {"amount": 150, "unit": "ml"},
+      "purchase_form": "bouteille",
+      "store": {
+        "coop": {
+          "search_terms": ["tamari"],
+          "preferred_section": "Épicerie du monde"
+        }
+      },
+      "recipes": ["Repas4"]
+    },
+    {
+      "slug": "haricots_blancs",
+      "display_name": "Haricots blancs cuits (bocal ou boîte)",
+      "category": "Épicerie sèche",
+      "quantity": {"amount": 400, "unit": "g"},
+      "purchase_form": "conserve",
+      "store": {
+        "coop": {
+          "search_terms": ["haricots blancs"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas5"]
+    },
+    {
+      "slug": "carottes",
+      "display_name": "Carottes",
+      "category": "Légumes",
+      "quantity": {"amount": 600, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["carottes"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas5", "Repas6"]
+    },
+    {
+      "slug": "blettes",
+      "display_name": "Blettes",
+      "category": "Légumes",
+      "quantity": {"amount": 1, "unit": "botte"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["blettes", "bettes"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas5"]
+    },
+    {
+      "slug": "origan",
+      "display_name": "Origan séché",
+      "category": "Épices & herbes",
+      "quantity": {"amount": 15, "unit": "g"},
+      "purchase_form": "sec",
+      "store": {
+        "coop": {
+          "search_terms": ["origan"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas5"]
+    },
+    {
+      "slug": "cabillaud",
+      "display_name": "Filets de cabillaud",
+      "category": "Poissonnerie",
+      "quantity": {"amount": 300, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["cabillaud frais"],
+          "preferred_section": "Poissonnerie"
+        }
+      },
+      "recipes": ["Repas6"]
+    },
+    {
+      "slug": "panais",
+      "display_name": "Panais",
+      "category": "Légumes",
+      "quantity": {"amount": 300, "unit": "g"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["panais"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas6"]
+    },
+    {
+      "slug": "poireau",
+      "display_name": "Poireaux",
+      "category": "Légumes",
+      "quantity": {"amount": 2, "unit": "pièces"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["poireau"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas6"]
+    },
+    {
+      "slug": "huile_olive",
+      "display_name": "Huile d'olive vierge extra",
+      "category": "Épicerie",
+      "quantity": {"amount": 500, "unit": "ml"},
+      "purchase_form": "bouteille",
+      "store": {
+        "coop": {
+          "search_terms": ["huile d'olive"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas6"]
+    },
+    {
+      "slug": "sarrasin",
+      "display_name": "Grains de sarrasin (kasha)",
+      "category": "Épicerie sèche",
+      "quantity": {"amount": 200, "unit": "g"},
+      "purchase_form": "sec",
+      "store": {
+        "coop": {
+          "search_terms": ["sarrasin"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas7"]
+    },
+    {
+      "slug": "bouillon_legumes",
+      "display_name": "Bouillon de légumes",
+      "category": "Épicerie",
+      "quantity": {"amount": 1, "unit": "l"},
+      "purchase_form": "liquide ou cube",
+      "store": {
+        "coop": {
+          "search_terms": ["bouillon légumes", "bouillon bio"],
+          "preferred_section": "Épicerie"
+        }
+      },
+      "recipes": ["Repas7"]
+    },
+    {
+      "slug": "petits_pois",
+      "display_name": "Petits pois surgelés",
+      "category": "Surgelés",
+      "quantity": {"amount": 300, "unit": "g"},
+      "purchase_form": "surgelé",
+      "store": {
+        "coop": {
+          "search_terms": ["petits pois surgelés"],
+          "preferred_section": "Surgelés"
+        }
+      },
+      "recipes": ["Repas7"]
+    },
+    {
+      "slug": "ciboulette",
+      "display_name": "Ciboulette fraîche",
+      "category": "Herbes fraîches",
+      "quantity": {"amount": 1, "unit": "botte"},
+      "purchase_form": "frais",
+      "store": {
+        "coop": {
+          "search_terms": ["ciboulette"],
+          "preferred_section": "Fruits & Légumes"
+        }
+      },
+      "recipes": ["Repas7"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- populate `courses.json` with a structured shopping list generated from the current menus
- aggregate repeated ingredients, estimate quantities for two people, and add store search hints for Coop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5878ff7083298ee6f40313ddf147