### PR TITLE
feat: historize weekly menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ RecettesAuto/
 
 1. **Configuration** (`data/config.json`)
    - Nombre de personnes, régimes, préférences, contraintes d’achat.
+   - Nouveau paramètre `options.semaines_historique` pour définir combien de semaines
+     récentes sont consultées afin d’éviter les répétitions de plats.
 2. **Menus** (`data/menus.json`)
-   - Génération via l’API GPT.
+   - Génération via l’API GPT en tenant compte de l’historique.
    - Validation/refus des propositions.
 3. **Stock** (`data/stock.json`)
    - Tenir à jour les ingrédients disponibles (Raccourcis iOS, etc.).
@@ -57,6 +59,14 @@ python main.py
 - **Modifier le stock** : met à jour `data/stock.json`.
 - **Valider les menus** : change l’état des repas (proposé, validé, refusé).
 - **Générer les courses** : (à venir) appel à l’API GPT puis écriture de `data/courses.json`.
+
+## 🗂️ Historique des menus
+
+- Le fichier `data/menus.json` est désormais organisé par semaine (format `YYYY-Www`).
+- Chaque génération crée une nouvelle entrée sans écraser les précédentes, ce qui permet
+  de conserver un historique complet.
+- Lors de la génération, RecettesAuto consulte automatiquement les `semaines_historique`
+  dernières semaines définies dans la configuration pour éviter de reproposer les mêmes plats.
 
 ## 🔒 Configuration OpenAI
 

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -69,6 +69,14 @@ def validate_config(config: Dict[str, Any]) -> Tuple[bool, List[str]]:
         if section in config and not isinstance(config[section], dict):
             errors.append(f"La section '{section}' doit être un objet JSON.")
 
+    options = config.get("options", {}) if isinstance(config.get("options", {}), dict) else {}
+    weeks_history = options.get("semaines_historique")
+    if weeks_history is not None:
+        if not isinstance(weeks_history, int) or weeks_history < 0:
+            errors.append(
+                "L'option 'semaines_historique' doit être un entier supérieur ou égal à 0."
+            )
+
     return not errors, errors
 
 

--- a/core/courses_manager.py
+++ b/core/courses_manager.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 from . import DATA_DIR
 from .config_manager import load_and_validate
 from .gpt_api import ask_gpt
-from .menu_manager import load_menus
+from .menu_manager import get_week_identifier, load_menus
 from .stock_manager import load_stock
 
 COURSES_PATH = DATA_DIR / "courses.json"
@@ -38,7 +38,8 @@ def generate_courses(*, path: Path | None = None) -> Dict[str, Any]:
     """Demande à GPT de produire une nouvelle liste de courses."""
 
     config = load_and_validate()
-    menus = load_menus()
+    current_week = get_week_identifier()
+    menus = load_menus(week_id=current_week)
     stock = load_stock()
 
     prompt = (
@@ -49,6 +50,7 @@ def generate_courses(*, path: Path | None = None) -> Dict[str, Any]:
     payload = {
         "config": config,
         "menus": menus,
+        "semaine_courante": current_week,
         "stock": stock,
     }
 

--- a/core/menu_manager.py
+++ b/core/menu_manager.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List, Tuple
 
 from . import DATA_DIR
 from .config_manager import load_and_validate
@@ -13,14 +14,74 @@ from .gpt_api import ask_gpt
 MENUS_PATH = DATA_DIR / "menus.json"
 
 
-def load_menus(path: Path | None = None) -> Dict[str, Any]:
+def get_week_identifier(for_date: date | None = None) -> str:
+    """Retourne l'identifiant ISO (``YYYY-Www``) d'une semaine."""
+
+    target_date = for_date or date.today()
+    iso = target_date.isocalendar()
+    return f"{iso.year}-W{iso.week:02d}"
+
+
+def _parse_week_identifier(week_id: str) -> Tuple[int, int]:
+    """Convertit un identifiant de semaine en tuple ``(année, semaine)``."""
+
+    try:
+        year_str, week_str = week_id.split("-W", maxsplit=1)
+        return int(year_str), int(week_str)
+    except (ValueError, AttributeError):  # pragma: no cover - defensive
+        return (0, 0)
+
+
+def _sorted_weeks(menus_by_week: Dict[str, Any]) -> List[str]:
+    """Retourne les identifiants de semaines triés chronologiquement."""
+
+    return sorted(menus_by_week.keys(), key=_parse_week_identifier, reverse=True)
+
+
+def _select_recent_weeks(
+    menus_by_week: Dict[str, Any],
+    weeks_to_consult: int,
+    current_week: str,
+) -> List[str]:
+    """Sélectionne les ``weeks_to_consult`` semaines précédentes disponibles."""
+
+    if weeks_to_consult <= 0:
+        return []
+
+    ordered_weeks = [week for week in _sorted_weeks(menus_by_week) if week != current_week]
+    return ordered_weeks[:weeks_to_consult]
+
+
+def _collect_titles(menus: Iterable[Dict[str, Any]]) -> List[str]:
+    """Extrait la liste dédoublonnée des titres de menus fournis."""
+
+    titles = set()
+    for week_menus in menus:
+        if not isinstance(week_menus, dict):
+            continue
+        for entry in week_menus.values():
+            if not isinstance(entry, dict):
+                continue
+            titre = entry.get("Titre")
+            if titre:
+                titles.add(titre)
+    return sorted(titles)
+
+
+def load_menus(path: Path | None = None, *, week_id: str | None = None) -> Dict[str, Any]:
     """Retourne le contenu du fichier ``menus.json``."""
 
     target_path = path or MENUS_PATH
     if not target_path.exists():
         return {}
     with target_path.open("r", encoding="utf-8") as file:
-        return json.load(file)
+        menus: Dict[str, Any] = json.load(file)
+
+    if week_id is None:
+        return menus
+
+    week_menus = menus.get(week_id)
+    return week_menus if isinstance(week_menus, dict) else {}
 
 
 def save_menus(menus: Dict[str, Any], path: Path | None = None) -> None:
@@ -32,31 +93,64 @@ def save_menus(menus: Dict[str, Any], path: Path | None = None) -> None:
         json.dump(menus, file, ensure_ascii=False, indent=2)
 
 
-def update_menu_state(menu_id: str, state: str, *, path: Path | None = None) -> Dict[str, Any]:
+def update_menu_state(
+    menu_id: str, state: str, *, week_id: str | None = None, path: Path | None = None
+) -> Dict[str, Any]:
     """Met à jour l’état d’un repas (proposé, validé, refusé, etc.)."""
 
-    menus = load_menus(path)
-    if menu_id not in menus:
-        raise KeyError(f"Le menu '{menu_id}' est introuvable.")
-    menus[menu_id]["État"] = state
-    save_menus(menus, path)
-    return menus
+    menus_by_week = load_menus(path)
+    target_week = week_id or get_week_identifier()
+    if target_week not in menus_by_week or not isinstance(menus_by_week[target_week], dict):
+        raise KeyError(f"La semaine '{target_week}' est introuvable.")
+
+    week_menus = menus_by_week[target_week]
+    if menu_id not in week_menus:
+        raise KeyError(f"Le menu '{menu_id}' est introuvable pour la semaine '{target_week}'.")
+
+    week_menus[menu_id]["État"] = state
+    save_menus(menus_by_week, path)
+    return week_menus
 
 
 def generate_menus(*, prompt: str | None = None, path: Path | None = None) -> Dict[str, Any]:
     """Génère de nouveaux menus via GPT et les enregistre."""
 
     config = load_and_validate()
-    current_menus = load_menus(path)
+    menus_by_week = load_menus(path)
+    current_week = get_week_identifier()
 
-    base_prompt = prompt or (
-        "Propose un menu hebdomadaire en JSON pour {nb} personnes en respectant les régimes "
-        "et préférences fournis. Réponds uniquement avec du JSON."
-    ).format(nb=config["nombre_personnes"])
+    weeks_to_consult = (
+        config.get("options", {}).get("semaines_historique")
+        if isinstance(config.get("options", {}), dict)
+        else None
+    )
+    weeks_to_consult = weeks_to_consult if isinstance(weeks_to_consult, int) else 0
+    previous_weeks = _select_recent_weeks(menus_by_week, weeks_to_consult, current_week)
+    previous_menus = [menus_by_week[week] for week in previous_weeks]
+
+    if weeks_to_consult > 0:
+        default_prompt = (
+            "Propose un menu hebdomadaire en JSON pour {nb} personnes en respectant les régimes "
+            "et préférences fournis. Évite de répéter les plats servis durant les {nb_semaines} "
+            "dernières semaines. Réponds uniquement avec du JSON."
+        )
+    else:
+        default_prompt = (
+            "Propose un menu hebdomadaire en JSON pour {nb} personnes en respectant les régimes "
+            "et préférences fournis. Réponds uniquement avec du JSON."
+        )
+
+    base_prompt = (prompt or default_prompt).format(
+        nb=config["nombre_personnes"],
+        nb_semaines=weeks_to_consult,
+    )
 
     payload = {
         "config": config,
-        "menus_existants": current_menus,
+        "semaine_courante": current_week,
+        "menus_existants": menus_by_week.get(current_week, {}),
+        "historique_menus": {week: menus_by_week[week] for week in previous_weeks},
+        "historique_plats": _collect_titles(previous_menus),
     }
 
     response = ask_gpt(base_prompt, payload)
@@ -70,11 +164,24 @@ def generate_menus(*, prompt: str | None = None, path: Path | None = None) -> Di
     else:
         menus = response
 
-    save_menus(menus, path)
+    menus_by_week[current_week] = menus
+    save_menus(menus_by_week, path)
     return menus
 
 
 def list_menu_states(menus: Dict[str, Any]) -> List[str]:
     """Retourne la liste des états distincts présents dans les menus."""
 
-    return sorted({entry.get("État", "") for entry in menus.values()})
+    states = set()
+
+    def _walk(entries: Dict[str, Any]) -> None:
+        for value in entries.values():
+            if isinstance(value, dict):
+                if "État" in value:
+                    states.add(value.get("État", ""))
+                else:
+                    _walk(value)
+
+    _walk(menus)
+    states.discard("")
+    return sorted(states)

--- a/data/config.json
+++ b/data/config.json
@@ -20,7 +20,8 @@
   },
   "options": {
     "saisonnalite": true,
-    "frequence_generation": "hebdomadaire"
+    "frequence_generation": "hebdomadaire",
+    "semaines_historique": 4
   },
   "achats": {
     "priorite_bio": true,

--- a/data/menus.json
+++ b/data/menus.json
@@ -1,79 +1,81 @@
 {
-  "Repas1": {
-    "Titre": "Curry de lentilles corail",
-    "Ingrédients": [
-      "lentilles",
-      "lait_coco",
-      "epinards",
-      "patate_douce",
-      "gingembre"
-    ],
-    "État": "proposé"
-  },
-  "Repas2": {
-    "Titre": "Salade de pois chiches croustillants",
-    "Ingrédients": [
-      "pois_chiches",
-      "tomates",
-      "concombre",
-      "persil",
-      "citron"
-    ],
-    "État": "proposé"
-  },
-  "Repas3": {
-    "Titre": "Saumon au four et quinoa",
-    "Ingrédients": [
-      "saumon",
-      "quinoa",
-      "courgettes",
-      "citron",
-      "aneth"
-    ],
-    "État": "proposé"
-  },
-  "Repas4": {
-    "Titre": "Tofu fumé et brocoli sauté",
-    "Ingrédients": [
-      "tofu",
-      "brocoli",
-      "champignons",
-      "ail",
-      "tamari"
-    ],
-    "État": "proposé"
-  },
-  "Repas5": {
-    "Titre": "Soupe minestrone aux haricots blancs",
-    "Ingrédients": [
-      "haricots_blancs",
-      "carottes",
-      "blettes",
-      "tomates",
-      "origan"
-    ],
-    "État": "proposé"
-  },
-  "Repas6": {
-    "Titre": "Cabillaud vapeur et légumes racines",
-    "Ingrédients": [
-      "cabillaud",
-      "panais",
-      "carottes",
-      "poireau",
-      "huile_olive"
-    ],
-    "État": "proposé"
-  },
-  "Repas7": {
-    "Titre": "Risotto de sarrasin aux champignons",
-    "Ingrédients": [
-      "sarrasin",
-      "champignons",
-      "bouillon_legumes",
-      "petits_pois",
-      "ciboulette"
-    ],
-    "État": "proposé"
+  "2025-W40": {
+    "Repas1": {
+      "Titre": "Curry de lentilles corail",
+      "Ingrédients": [
+        "lentilles",
+        "lait_coco",
+        "epinards",
+        "patate_douce",
+        "gingembre"
+      ],
+      "État": "proposé"
+    },
+    "Repas2": {
+      "Titre": "Salade de pois chiches croustillants",
+      "Ingrédients": [
+        "pois_chiches",
+        "tomates",
+        "concombre",
+        "persil",
+        "citron"
+      ],
+      "État": "proposé"
+    },
+    "Repas3": {
+      "Titre": "Saumon au four et quinoa",
+      "Ingrédients": [
+        "saumon",
+        "quinoa",
+        "courgettes",
+        "citron",
+        "aneth"
+      ],
+      "État": "proposé"
+    },
+    "Repas4": {
+      "Titre": "Tofu fumé et brocoli sauté",
+      "Ingrédients": [
+        "tofu",
+        "brocoli",
+        "champignons",
+        "ail",
+        "tamari"
+      ],
+      "État": "proposé"
+    },
+    "Repas5": {
+      "Titre": "Soupe minestrone aux haricots blancs",
+      "Ingrédients": [
+        "haricots_blancs",
+        "carottes",
+        "blettes",
+        "tomates",
+        "origan"
+      ],
+      "État": "proposé"
+    },
+    "Repas6": {
+      "Titre": "Cabillaud vapeur et légumes racines",
+      "Ingrédients": [
+        "cabillaud",
+        "panais",
+        "carottes",
+        "poireau",
+        "huile_olive"
+      ],
+      "État": "proposé"
+    },
+    "Repas7": {
+      "Titre": "Risotto de sarrasin aux champignons",
+      "Ingrédients": [
+        "sarrasin",
+        "champignons",
+        "bouillon_legumes",
+        "petits_pois",
+        "ciboulette"
+      ],
+      "État": "proposé"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- restructure menu storage to keep an ISO-week history and document the change
- make menu generation consult a configurable number of previous weeks to avoid duplicates
- update course generation to use the current week menus and pass the week context

## Testing
- python -m compileall core main.py

------
https://chatgpt.com/codex/tasks/task_e_68dec71e3cc48329b31fbf2a4c414413