### PR TITLE
Support .env for OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ python main.py
 ## 🔒 Configuration OpenAI
 
 Renseigner la variable d’environnement `OPENAI_API_KEY` avant d’appeler les fonctions utilisant l’API.
+
+Vous pouvez la définir directement dans votre shell (`export OPENAI_API_KEY=...`) **ou** créer un fichier `.env`
+à la racine du projet contenant une ligne `OPENAI_API_KEY=...`. Le chargeur intégré lit automatiquement ce
+fichier et n’écrase jamais une variable déjà présente dans l’environnement.


### PR DESCRIPTION
## Summary
- load environment variables from a local .env file so OPENAI_API_KEY can be read automatically
- document the new .env support in the README

## Testing
- python -m compileall core main.py

------
https://chatgpt.com/codex/tasks/task_e_68ded0756cf08329bae11de2f6826e00