### PR TITLE
Add static recipe viewer for shortcut-generated daily meals

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ RecettesAuto/
 │   ├── courses.json
 │   ├── menus.json
 │   └── stock.json
+├── RecettesUtils/
+│   ├── recette.html
+│   ├── recette_du_jour.json
+│   ├── script.js
+│   └── style.css
 ├── core/
 │   ├── config_manager.py
 │   ├── courses_manager.py
@@ -25,6 +30,7 @@ RecettesAuto/
 
 - **`data/`** : fichiers JSON utilisés par l’application.
 - **`core/`** : logique métier (gestion de la config, du stock, des menus et des courses, + wrapper OpenAI).
+- **`RecettesUtils/`** : utilitaire HTML/CSS/JS autonome pour consulter la recette finale du jour depuis iCloud.
 - **`coop_agent/`** : futur script Playwright pour automatiser l’ajout au panier Coop.ch.
 - **`main.py`** : point d’entrée orchestrant l’ensemble du workflow.
 - **`requirements.txt`** : dépendances Python.
@@ -59,6 +65,21 @@ python main.py
 - **Modifier le stock** : met à jour `data/stock.json`.
 - **Valider les menus** : change l’état des repas (proposé, validé, refusé).
 - **Générer les courses** : (à venir) appel à l’API GPT puis écriture de `data/courses.json`.
+
+## 📖 Utilitaire HTML « Recette du jour »
+
+Le dossier `RecettesUtils/` peut être copié tel quel dans `iCloud Drive/Raccourcis/RecettesUtils/`.
+Il contient une page statique qui lit le fichier `recette_du_jour.json` enregistré par un raccourci iOS :
+
+1. Le raccourci interroge l’API ChatGPT et génère un JSON structuré (titre, description, ingrédients, étapes).
+2. Le JSON est sauvegardé sous `recette_du_jour.json` dans le même dossier iCloud.
+3. En ouvrant `recette.html`, le script charge ce fichier et affiche automatiquement :
+   - une introduction (titre + description),
+   - la liste des ingrédients,
+   - la recette complète d’un seul bloc,
+   - un mode pas-à-pas en plein écran avec boutons « Précédent/Suivant ».
+
+Le fichier `recette_du_jour.json` fourni est un exemple : il peut être remplacé librement par le raccourci.
 
 ## 🗂️ Historique des menus
 

--- a/RecettesUtils/recette.html
+++ b/RecettesUtils/recette.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Recette du jour</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1 id="app-title">Recette du jour</h1>
+    <nav class="app-nav" aria-label="Sections de la recette">
+      <button type="button" class="nav-button active" data-target="intro">Introduction</button>
+      <button type="button" class="nav-button" data-target="ingredients">Ingrédients</button>
+      <button type="button" class="nav-button" data-target="recette">Recette complète</button>
+      <button type="button" class="nav-button" data-target="etapes">Étapes</button>
+    </nav>
+  </header>
+
+  <main>
+    <section id="intro" class="panel active" aria-live="polite">
+      <h2>Introduction</h2>
+      <p id="recette-description" class="description"></p>
+    </section>
+
+    <section id="ingredients" class="panel" aria-live="polite">
+      <h2>Ingrédients</h2>
+      <ul id="ingredients-list" class="ingredients"></ul>
+    </section>
+
+    <section id="recette" class="panel" aria-live="polite">
+      <h2>Recette complète</h2>
+      <article id="recette-complete" class="recette-complete"></article>
+    </section>
+
+    <section id="etapes" class="panel" aria-live="polite">
+      <h2>Étapes</h2>
+      <div class="etapes-viewer">
+        <div id="etape-contenu" class="etape-contenu"></div>
+        <div class="etapes-controls">
+          <button type="button" id="precedent" class="control-button">Précédent</button>
+          <div id="etape-compteur" class="etape-compteur" aria-live="polite"></div>
+          <button type="button" id="suivant" class="control-button">Suivant</button>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <p>Les données sont chargées depuis <code>recette_du_jour.json</code>.</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/RecettesUtils/recette_du_jour.json
+++ b/RecettesUtils/recette_du_jour.json
@@ -1,0 +1,33 @@
+{
+  "titre": "Velouté de potimarron épicé",
+  "description": "Un velouté réconfortant et parfumé, prêt en moins de 30 minutes.",
+  "ingredients": [
+    "1 petit potimarron (environ 800 g)",
+    "1 oignon jaune",
+    "1 gousse d'ail",
+    "70 cl de bouillon de légumes",
+    "10 cl de lait de coco",
+    "1 c. à soupe d'huile d'olive",
+    "1 c. à café de curry doux",
+    "Sel, poivre"
+  ],
+  "recette_complete": "Épluchez et taillez le potimarron en cubes. Faites revenir l'oignon et l'ail émincés dans l'huile d'olive avec le curry. Ajoutez le potimarron, mélangez puis versez le bouillon. Laissez mijoter 20 minutes, mixez avec le lait de coco et assaisonnez.",
+  "etapes": [
+    {
+      "titre": "Préparer les légumes",
+      "instructions": "Épluchez le potimarron, retirez les graines et coupez la chair en cubes réguliers. Émincez finement l'oignon et l'ail."
+    },
+    {
+      "titre": "Faire revenir",
+      "instructions": "Dans une grande casserole, chauffez l'huile d'olive. Faites-y revenir l'oignon et l'ail avec le curry pendant 2 minutes."
+    },
+    {
+      "titre": "Cuisson",
+      "instructions": "Ajoutez les cubes de potimarron, mélangez bien puis versez le bouillon. Laissez mijoter à couvert pendant 20 minutes, jusqu'à ce que la chair soit tendre."
+    },
+    {
+      "titre": "Mixer et servir",
+      "instructions": "Ajoutez le lait de coco, mixez jusqu'à obtenir une texture veloutée puis assaisonnez de sel et de poivre. Servez bien chaud."
+    }
+  ]
+}

--- a/RecettesUtils/script.js
+++ b/RecettesUtils/script.js
@@ -1,0 +1,189 @@
+const state = {
+  etapes: [],
+  indexEtape: 0,
+};
+
+const selectors = {
+  titre: document.getElementById("app-title"),
+  description: document.getElementById("recette-description"),
+  ingredients: document.getElementById("ingredients-list"),
+  recetteComplete: document.getElementById("recette-complete"),
+  etapeContenu: document.getElementById("etape-contenu"),
+  etapeCompteur: document.getElementById("etape-compteur"),
+  precedent: document.getElementById("precedent"),
+  suivant: document.getElementById("suivant"),
+  panels: Array.from(document.querySelectorAll(".panel")),
+  navButtons: Array.from(document.querySelectorAll(".nav-button")),
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  chargerRecette();
+  initialiserNavigation();
+  initialiserControleEtapes();
+});
+
+async function chargerRecette() {
+  try {
+    const response = await fetch("recette_du_jour.json", { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Impossible de lire recette_du_jour.json (status ${response.status})`);
+    }
+
+    const data = await response.json();
+    renseignerInterface(data);
+  } catch (error) {
+    console.error(error);
+    afficherErreur(
+      "Impossible de charger la recette du jour. Vérifiez que le fichier recette_du_jour.json est présent dans le même dossier."
+    );
+  }
+}
+
+function renseignerInterface(data) {
+  const titre = data.titre || "Recette du jour";
+  document.title = titre;
+  selectors.titre.textContent = titre;
+  selectors.description.textContent = data.description ||
+    "Ajoutez une description dans votre fichier recette_du_jour.json pour voir un aperçu ici.";
+
+  mettreAJourIngredients(data.ingredients);
+  mettreAJourRecetteComplete(data);
+  mettreAJourEtapes(data.etapes);
+}
+
+function mettreAJourIngredients(ingredients) {
+  selectors.ingredients.innerHTML = "";
+  if (!Array.isArray(ingredients) || ingredients.length === 0) {
+    const item = document.createElement("li");
+    item.textContent = "Aucun ingrédient trouvé. Ajoutez des entrées dans la propriété \"ingredients\".";
+    selectors.ingredients.appendChild(item);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const ingr of ingredients) {
+    const item = document.createElement("li");
+    item.textContent = ingr;
+    fragment.appendChild(item);
+  }
+  selectors.ingredients.appendChild(fragment);
+}
+
+function mettreAJourRecetteComplete(data) {
+  let texteComplet =
+    data.recette_complete ||
+    data.recetteComplete ||
+    (Array.isArray(data.etapes)
+      ? data.etapes
+          .map((etape, index) =>
+            `${index + 1}. ${etape.titre ? `${etape.titre} - ` : ""}${etape.instructions || etape}`.trim()
+          )
+          .join("\n\n")
+      : "");
+
+  if (!texteComplet) {
+    texteComplet =
+      "Ajoutez un champ \"recette_complete\" ou \"recetteComplete\" dans votre JSON, ou une liste d'étapes pour générer le texte complet.";
+  }
+
+  selectors.recetteComplete.textContent = texteComplet;
+}
+
+function mettreAJourEtapes(etapes) {
+  if (!Array.isArray(etapes) || etapes.length === 0) {
+    state.etapes = [];
+    selectors.etapeContenu.innerHTML =
+      "<p>Aucune étape trouvée. Ajoutez un tableau \"etapes\" avec des instructions.</p>";
+    selectors.precedent.disabled = true;
+    selectors.suivant.disabled = true;
+    selectors.etapeCompteur.textContent = "";
+    return;
+  }
+
+  state.etapes = etapes.map((etape, index) => {
+    if (typeof etape === "string") {
+      return { titre: `Étape ${index + 1}`, instructions: etape };
+    }
+    return {
+      titre: etape.titre || `Étape ${index + 1}`,
+      instructions: etape.instructions || "",
+    };
+  });
+
+  state.indexEtape = 0;
+  mettreAJourVueEtape();
+}
+
+function mettreAJourVueEtape() {
+  if (state.etapes.length === 0) {
+    return;
+  }
+
+  const etape = state.etapes[state.indexEtape];
+  selectors.etapeContenu.innerHTML = "";
+
+  const titre = document.createElement("h3");
+  titre.className = "etape-titre";
+  titre.textContent = etape.titre;
+
+  const instructions = document.createElement("p");
+  instructions.textContent = etape.instructions;
+
+  selectors.etapeContenu.append(titre, instructions);
+
+  selectors.etapeCompteur.textContent = `${state.indexEtape + 1} / ${state.etapes.length}`;
+
+  selectors.precedent.disabled = state.indexEtape === 0;
+  selectors.suivant.textContent =
+    state.indexEtape === state.etapes.length - 1 ? "Terminer" : "Suivant";
+}
+
+function initialiserNavigation() {
+  selectors.navButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const targetId = button.dataset.target;
+      afficherSection(targetId);
+    });
+  });
+}
+
+function afficherSection(id) {
+  selectors.panels.forEach((panel) => {
+    panel.classList.toggle("active", panel.id === id);
+  });
+
+  selectors.navButtons.forEach((button) => {
+    button.classList.toggle("active", button.dataset.target === id);
+  });
+}
+
+function initialiserControleEtapes() {
+  selectors.precedent.addEventListener("click", () => {
+    if (state.indexEtape > 0) {
+      state.indexEtape -= 1;
+      mettreAJourVueEtape();
+    }
+  });
+
+  selectors.suivant.addEventListener("click", () => {
+    if (state.indexEtape < state.etapes.length - 1) {
+      state.indexEtape += 1;
+      mettreAJourVueEtape();
+    } else {
+      state.indexEtape = 0;
+      mettreAJourVueEtape();
+      afficherSection("intro");
+    }
+  });
+}
+
+function afficherErreur(message) {
+  selectors.description.textContent = message;
+  selectors.ingredients.innerHTML = "";
+  selectors.recetteComplete.textContent = "";
+  selectors.etapeContenu.innerHTML = `<p>${message}</p>`;
+  selectors.precedent.disabled = true;
+  selectors.suivant.disabled = true;
+  selectors.etapeCompteur.textContent = "";
+}
+

--- a/RecettesUtils/style.css
+++ b/RecettesUtils/style.css
@@ -1,0 +1,211 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: #f8f5f1;
+  --fg-color: #2d2a26;
+  --accent-color: #f28f3b;
+  --accent-dark: #c96c1b;
+  --panel-bg: rgba(255, 255, 255, 0.9);
+  --border-radius: 18px;
+  --shadow: 0 20px 45px rgba(0, 0, 0, 0.1);
+  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #fffaf3, var(--bg-color));
+  color: var(--fg-color);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 1.2rem clamp(1rem, 4vw, 4rem);
+  background: linear-gradient(120deg, var(--accent-color), #f7d08f);
+  color: #fff;
+  box-shadow: var(--shadow);
+}
+
+.app-header h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(1.5rem, 4vw, 2.75rem);
+  letter-spacing: 0.02em;
+}
+
+.app-nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem;
+}
+
+.nav-button {
+  border: none;
+  padding: 0.8rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.nav-button:hover,
+.nav-button:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.nav-button.active {
+  background: #fff;
+  color: var(--accent-dark);
+}
+
+main {
+  flex: 1 0 auto;
+  padding: clamp(1rem, 5vw, 4rem);
+  display: grid;
+  place-items: center;
+}
+
+.panel {
+  width: min(900px, 100%);
+  background: var(--panel-bg);
+  backdrop-filter: blur(20px);
+  border-radius: var(--border-radius);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  box-shadow: var(--shadow);
+  display: none;
+}
+
+.panel.active {
+  display: block;
+  animation: fadeInUp 0.35s ease;
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: clamp(1.4rem, 3vw, 2.2rem);
+}
+
+.description {
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.ingredients {
+  padding-left: 1.2rem;
+  line-height: 1.8;
+  font-size: 1.05rem;
+}
+
+.ingredients li + li {
+  margin-top: 0.35rem;
+}
+
+.recette-complete {
+  font-size: 1.05rem;
+  line-height: 1.8;
+  white-space: pre-line;
+}
+
+.etapes-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 60vh;
+}
+
+.etape-contenu {
+  flex: 1;
+  background: #fff;
+  border-radius: var(--border-radius);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+  font-size: clamp(1.15rem, 3vw, 1.6rem);
+  line-height: 1.8;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+}
+
+.etape-titre {
+  font-size: clamp(1.3rem, 3vw, 1.9rem);
+  margin: 0;
+  color: var(--accent-dark);
+}
+
+.etapes-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.control-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.8rem;
+  background: var(--accent-color);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(242, 143, 59, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.control-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.control-button:hover:not(:disabled),
+.control-button:focus-visible:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(242, 143, 59, 0.5);
+}
+
+.etape-compteur {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent-dark);
+}
+
+.app-footer {
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(45, 42, 38, 0.7);
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #1d1b18;
+    --fg-color: #f1ede6;
+    --panel-bg: rgba(33, 30, 27, 0.85);
+    --shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
+  }
+
+  .etape-contenu {
+    background: rgba(12, 12, 12, 0.55);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  }
+
+  .app-footer {
+    color: rgba(241, 237, 230, 0.6);
+  }
+}


### PR DESCRIPTION
## Summary
- add a RecettesUtils helper folder with a static HTML/CSS/JS viewer
- load the daily recipe JSON to populate introduction, ingredients, full recipe, and stepper views
- document how to deploy and use the utility from iCloud in the README

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfce33463483298acf2371dae3d7d2