### PR TITLE
Handle local file access for recette viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Il contient une page statique qui lit le fichier `recette_du_jour.json` enregist
    - la recette complète d’un seul bloc,
    - un mode pas-à-pas en plein écran avec boutons « Précédent/Suivant ».
 
+> 💡 **Astuce** : les navigateurs modernes bloquent les requêtes `fetch` depuis un fichier ouvert directement (`file://`).
+> Pour prévisualiser la page en local, lance un petit serveur HTTP depuis la racine du dossier :
+
+```bash
+python -m http.server --directory RecettesUtils 8000
+```
+
+Ensuite, ouvre [http://localhost:8000/recette.html](http://localhost:8000/recette.html) dans ton navigateur pour charger correctement la recette du jour.
+
 Le fichier `recette_du_jour.json` fourni est un exemple : il peut être remplacé librement par le raccourci.
 
 ## 🗂️ Historique des menus

--- a/RecettesUtils/script.js
+++ b/RecettesUtils/script.js
@@ -23,6 +23,13 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 async function chargerRecette() {
+  if (window.location.protocol === "file:") {
+    afficherErreur(
+      "Impossible de charger la recette du jour en ouvrant directement le fichier. Lancez un serveur HTTP local (par exemple : python -m http.server --directory RecettesUtils 8000) puis ouvrez http://localhost:8000/recette.html."
+    );
+    return;
+  }
+
   try {
     const response = await fetch("recette_du_jour.json", { cache: "no-store" });
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- prevent the recette viewer from attempting to fetch JSON when opened via the file protocol
- document how to launch a local HTTP server and access the recette viewer in a browser

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfdcf1ac108329baf5e317e57f9741